### PR TITLE
added location to nginx site.conf

### DIFF
--- a/data/nginx/site.conf
+++ b/data/nginx/site.conf
@@ -14,6 +14,10 @@ server {
     fastcgi_buffers 4 256k;
     fastcgi_busy_buffers_size 256k;
 
+    location / {
+      try_files $uri $uri/ /index.php?$args;
+    }
+
     location ~ \.php$ {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;


### PR DESCRIPTION
This will solve 404's when trying to access nested routes in WordPress.